### PR TITLE
Updated the correct location of the code featured

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To fully take advantage of BrowserSync's live stylesheet injection, besure to co
 ```
 After running `npm install`, Node will search the `scripts` object in `package.json` for `postinstall`, and will run the script if specified. `gulp build` compiles your assets. The build can be set up differently for different Rails environments. See below. A note about `dependencies`. Services like Heroku will ignore anything in `devDependences`, since it's techincally a production environment. So be sure to put anything your build process needs to run in `dependencies`, NOT `devDependencies.`
 
-### gulp/tasks/rev.js
+### gulp/tasks/build.js
 ```js
 // line 6
 if(process.env.RAILS_ENV === 'production') tasks.push('rev');


### PR DESCRIPTION
The code listed in the example isn't in the `rev.js` file, it's in the `build.js` one.
