### PR TITLE
Transform JS with babelify for ES6 support

### DIFF
--- a/gulp/assets/javascripts/message.js
+++ b/gulp/assets/javascripts/message.js
@@ -1,1 +1,5 @@
-module.exports = 'yay modules!';
+import name from './name';
+
+var message = `Hello ${name}!`;
+
+export default message;

--- a/gulp/assets/javascripts/name.js
+++ b/gulp/assets/javascripts/name.js
@@ -1,0 +1,1 @@
+export default 'Adam';

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -41,5 +41,8 @@ module.exports = {
       outputName: 'global.js',
       extensions: ['.js','.coffee']
     }]
+  },
+  babelify: {
+    stage: 1
   }
 };

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -2,15 +2,16 @@ var _            = require('lodash');
 var browserify   = require('browserify');
 var browserSync  = require('browser-sync');
 var bundleLogger = require('../util/bundleLogger');
-var config       = require('../config').browserify;
+var config       = require('../config');
 var gulp         = require('gulp');
 var handleErrors = require('../util/handleErrors');
 var source       = require('vinyl-source-stream');
 var watchify     = require('watchify');
+var babelify     = require('babelify');
 
 var browserifyTask = function(callback, devMode) {
 
-  var bundleQueue = config.bundleConfigs.length;
+  var bundleQueue = config.browserify.bundleConfigs.length;
 
   var browserifyThis = function(bundleConfig) {
 
@@ -25,6 +26,7 @@ var browserifyTask = function(callback, devMode) {
       bundleLogger.start(bundleConfig.outputName);
 
       return b
+        .transform(babelify.configure(config.babelify))
         .bundle()
         .on('error', handleErrors)
         .pipe(source(bundleConfig.outputName))
@@ -56,7 +58,7 @@ var browserifyTask = function(callback, devMode) {
     return bundle();
   };
 
-  config.bundleConfigs.forEach(browserifyThis);
+  config.browserify.bundleConfigs.forEach(browserifyThis);
 };
 
 gulp.task('browserify', browserifyTask);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ]
   },
   "dependencies": {
+    "babelify": "^6.0.2",
     "browser-sync": "~2.4.0",
     "browserify": "^8.0.2",
     "coffeeify": "~0.7.0",


### PR DESCRIPTION
ES6 is pretty much standard these days :) And you can actually mix it with coffee.

I've also added export / import example.
