### PR TITLE
Downgrade sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'sqlite3', group: :development
 gem 'pg', group: :production # For heroku
+gem 'sprockets', '2.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,11 +63,11 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.5.1)
-    multi_json (1.10.1)
+    multi_json (1.11.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.1)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.0)
@@ -102,7 +102,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    sprockets (2.12.3)
+    sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -132,6 +132,10 @@ DEPENDENCIES
   pg
   rails (= 4.2.0)
   sass-rails (~> 5.0)
+  sprockets (= 2.11.0)
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.5

--- a/README.md
+++ b/README.md
@@ -19,11 +19,24 @@ Clone the repository
 git clone https://github.com/greypants/gulp-rails-pipeline.git
 ```
 
-Enter into the directory and run bundle install
+Enter into the directory and run bundle install.
 ```
 cd gulp-rails-pipeline
 bundle install
 ```
+
+If you are on mac you may be required to run the following to [install PostgreSQL libraries successfully](http://stackoverflow.com/a/28206009/1376627).
+
+    ARCHFLAGS="-arch x86_64" bundle install
+
+It is required to update sprockets to use an older `2.x` version to remove `self.js` from loaded resources for
+BrowserSync to work properly
+
+    bundle update sprockets
+
+or for mac
+
+    ARCHFLAGS="-arch x86_64" bundle update sprockets
 
 Install javascript dependencies. Once npm install runs, the `postinstall` setting in `package.json` will run `gulp build` and do an initial build of your assets.
 ```


### PR DESCRIPTION
CSS injection was not working for newest rails as sprockets was naming files as `self.js` and browsersync was not picking files with this name.
