### PR TITLE
Bump gulp-iconfont version

### DIFF
--- a/gulp/tasks/iconFont/generateIconSass.js
+++ b/gulp/tasks/iconFont/generateIconSass.js
@@ -3,14 +3,14 @@ var config   = require('../../config').iconFont;
 var template = require('gulp-swig');
 var rename   = require('gulp-rename');
 
-module.exports = function(codepoints, options) {
+module.exports = function(glyphs, options) {
 
   var iconSass = template({
     data: {
-      icons: codepoints.map(function(icon) {
+      icons: glyphs.map(function(glyph) {
         return {
-          name: icon.name,
-          code: icon.codepoint.toString(16)
+          name: glyph.name,
+          code: glyph.unicode[0].charCodeAt(0).toString(16).toUpperCase()
         }
       }),
       fontName: config.options.fontName,

--- a/gulp/tasks/iconFont/index.js
+++ b/gulp/tasks/iconFont/index.js
@@ -6,6 +6,6 @@ var generateIconSass = require('./generateIconSass');
 gulp.task('iconFont', function() {
   return gulp.src(config.src)
     .pipe(iconfont(config.options))
-    .on('codepoints', generateIconSass)
+    .on('glyphs', generateIconSass)
     .pipe(gulp.dest(config.dest));
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-changed": "^0.4.1",
     "gulp-filesize": "0.0.6",
-    "gulp-iconfont": "^1.0.0",
+    "gulp-iconfont": "^3.0.0",
     "gulp-imagemin": "^0.6.2",
     "gulp-notify": "^1.4.2",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
If a version for the `gulp-iconfont` package is not specified, the iconfont task will fail to produce the sass needed for generated fonts. This is because the `codepoints` event has been replaced with `glyphs` in more recent distributions of `gulp-iconfont`. There are also a couple of slight adjustments to the way the unicode characters are retrieved which is detailed [here](https://github.com/nfroidure/gulp-iconfont#make-your-css).

Unless there's a particular reason to keep `gulp-iconfont` at v1, I propose we bump the package version and adjust the iconfont task as required.

PS: love the example project — just followed your lead in a project of mine and ran across the above, hope you find the patch useful.
