### PR TITLE
browserify using required html

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,6 @@
 var publicAssets = "./public/assets";
 var sourceFiles  = "./gulp/assets";
+var stringify = require('stringify');
 
 module.exports = {
   publicAssets: publicAssets,
@@ -36,6 +37,10 @@ module.exports = {
   },
   browserify: {
     bundleConfigs: [{
+      transform: stringify({
+        extensions: ['.html'],
+         minify: true
+      }),
       entries: sourceFiles + '/javascripts/global.coffee',
       dest: publicAssets + '/javascripts',
       outputName: 'global.js',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "browser-sync": "~2.4.0",
-    "browserify": "^8.0.2",
+    "browserify": "^11.0.1",
     "coffeeify": "~0.7.0",
     "del": "^1.1.1",
     "gulp": "^3.8.7",
@@ -42,7 +42,8 @@
     "pretty-hrtime": "~0.2.1",
     "require-dir": "^0.1.0",
     "vinyl-source-stream": "~0.1.1",
-    "watchify": "^2.2.1"
+    "watchify": "^2.2.1",
+    "stringify": "^3.1.0"
   },
   "devDependencies": {
     "gulp-watch": "^4.1.1"


### PR DESCRIPTION
Added a possibility to import html within the browserify

exemple : require('../html/home.html')

Result in file global.js :

``` javascript
module.exports = "<div ng-controller=HomeController><input type=text ng-model=demo><h1 ng-click=clearText()>{{ demo }}</h1></div>";"
```
