### PR TITLE
write source maps after autoprefixer has run

### DIFF
--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -11,8 +11,8 @@ gulp.task('sass', function () {
     .pipe(sourcemaps.init())
     .pipe(sass(config.settings))
     .on('error', handleErrors)
-    .pipe(sourcemaps.write())
     .pipe(autoprefixer({ browsers: ['last 2 version'] }))
+    .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.dest))
     .pipe(browserSync.reload({stream:true}));
 });


### PR DESCRIPTION
Addresses errors that came from writing sourcemaps before autoprefixer.

Source - https://github.com/floridoo/gulp-sourcemaps/issues/60
Seems Google uses this ordering as well - https://github.com/google/web-starter-kit/commit/8c356e1bb9bbd5218ec533780b035beb6d9b035e
