### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^3.0.1",
     "gulp-rev-collector": "^0.1.3",
-    "gulp-sass": "~1.3.1",
+    "gulp-sass": "^2.0.4",
     "gulp-sequence": "^0.3.2",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-swig": "^0.7.4",


### PR DESCRIPTION
The previous version of gulp-sass doesn't work with node v4.0.0, but this version should allow it to work!
